### PR TITLE
feat: add you.com search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Choose your preferred text extraction engine:
 - **Semantic Scholar**: Add your [API Key](https://www.semanticscholar.org/product/api) for higher rate limits and faster searches.
 - **Firecrawl**: Add [API Key](https://firecrawl.dev) to enable deep web search capabilities - local instance with ([GitHub](https://github.com/firecrawl/firecrawl)).
 - **Tavily**: Add [API Key](https://tavily.com/) for optimized search results tailored for AI agents.
+- **You.com Search API**: Add [YDC API Key](https://you.com/platform) to enable an additional web search provider (`https://api.you.com/v1/agents/search`) with optional contents extraction support.
 
 ### 4. MCP Server & API
 

--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -317,6 +317,7 @@
       <menupopup>
         <menuitem value="firecrawl" label="Firecrawl" />
         <menuitem value="tavily" label="Tavily" />
+        <menuitem value="you" label="You.com" />
       </menupopup>
     </menulist>
   </hbox>
@@ -409,6 +410,51 @@
         "
       >
         🖥️ Setup Firecrawl Locally
+      </html:a>
+    </hbox>
+  </vbox>
+
+  <!-- You.com Settings -->
+  <vbox
+    id="zotero-prefpane-__addonRef__-youSettings"
+    style="
+      margin-left: 20px;
+      margin-bottom: 12px;
+      padding: 10px;
+      background: rgba(0, 0, 0, 0.03);
+      border-radius: 4px;
+    "
+  >
+    <hbox align="center" style="margin-bottom: 8px">
+      <label style="width: 100px">API Key:</label>
+      <html:input
+        type="password"
+        id="zotero-prefpane-__addonRef__-youApiKey"
+        placeholder="YDC API key"
+        style="flex: 1; min-width: 200px"
+      ></html:input>
+    </hbox>
+    <hbox align="center" style="margin-bottom: 8px">
+      <label style="width: 100px">Search Limit:</label>
+      <html:input
+        type="number"
+        id="zotero-prefpane-__addonRef__-youSearchLimit"
+        placeholder="5"
+        min="1"
+        max="20"
+        style="width: 60px"
+      ></html:input>
+      <label style="margin-left: 8px; font-size: 11px; color: #666"
+        >Results per query (1-20)</label
+      >
+    </hbox>
+    <hbox align="center">
+      <html:a
+        href="https://you.com/platform"
+        style="color: #0066cc; text-decoration: underline; cursor: pointer; font-size: 12px"
+        onclick="Zotero.launchURL(this.href); return false;"
+      >
+        📖 Get API Key
       </html:a>
     </hbox>
   </vbox>

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -33,6 +33,9 @@ pref("nanogptWebSearchDepth", "standard"); // "standard" or "deep"
 pref("tavilyApiKey", "");
 pref("tavilySearchLimit", 5);
 pref("tavilySearchDepth", "basic");
+// You.com Search preferences
+pref("youApiKey", "");
+pref("youSearchLimit", 5);
 // Agentic mode preferences
 pref("agenticMode", true);
 pref("libraryScope", "all"); // "user", "all", "group:ID", or "collection:libID:colID"

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -306,6 +306,13 @@ function bindPrefEvents() {
     "tavilySearchLimit",
   );
 
+  // You.com settings
+  bindInput(`zotero-prefpane-${config.addonRef}-youApiKey`, "youApiKey");
+  bindInput(
+    `zotero-prefpane-${config.addonRef}-youSearchLimit`,
+    "youSearchLimit",
+  );
+
   // Tavily search depth menulist
   const tavilyDepthSelect = doc?.querySelector(
     `#zotero-prefpane-${config.addonRef}-tavilySearchDepth`,
@@ -330,12 +337,18 @@ function bindPrefEvents() {
     const tavilySettings = doc?.querySelector(
       `#zotero-prefpane-${config.addonRef}-tavilySettings`,
     ) as HTMLElement;
+    const youSettings = doc?.querySelector(
+      `#zotero-prefpane-${config.addonRef}-youSettings`,
+    ) as HTMLElement;
 
     if (firecrawlSettings) {
       firecrawlSettings.style.display = provider === "firecrawl" ? "" : "none";
     }
     if (tavilySettings) {
       tavilySettings.style.display = provider === "tavily" ? "" : "none";
+    }
+    if (youSettings) {
+      youSettings.style.display = provider === "you" ? "" : "none";
     }
   }
 

--- a/src/modules/webSearchProvider.ts
+++ b/src/modules/webSearchProvider.ts
@@ -13,10 +13,11 @@ import {
 } from "./firecrawl";
 import { tavilyService, WebSearchResult as TavilyResult } from "./tavily";
 import { nanogptWebService } from "./nanogptWeb";
+import { youSearchService } from "./youSearch";
 
 // ==================== Types ====================
 
-export type WebSearchProviderType = "firecrawl" | "tavily" | "nanogpt";
+export type WebSearchProviderType = "firecrawl" | "tavily" | "nanogpt" | "you";
 
 export interface WebSearchResult {
   url: string;
@@ -271,6 +272,43 @@ const firecrawlProvider = new FirecrawlProviderWrapper();
 const tavilyProvider = new TavilyProviderWrapper();
 const nanogptProvider = new NanogptProviderWrapper();
 
+class YouProviderWrapper implements WebSearchProvider {
+  isConfigured(): boolean {
+    return youSearchService.isConfigured();
+  }
+
+  async webSearch(query: string, limit?: number): Promise<WebSearchResult[]> {
+    return await youSearchService.webSearch(query, limit);
+  }
+
+  async scrapeUrl(url: string): Promise<WebSearchResult | null> {
+    return await youSearchService.scrapeUrl(url);
+  }
+
+  async researchSearch(): Promise<PdfDiscoveryResult | null> {
+    return null;
+  }
+
+  async searchForPdf(): Promise<PdfDiscoveryResult> {
+    return { source: "you", status: "not_found" };
+  }
+
+  getCachedPdfResult(): PdfDiscoveryResult | null | undefined {
+    return null;
+  }
+
+  setCachedPdfResult(): void {}
+  clearCache(): void {}
+  clearPdfCache(): void {}
+  clearPdfCacheForPaper(): void {}
+
+  getSearchLimit(): number {
+    return youSearchService.getSearchLimit();
+  }
+}
+
+const youProvider = new YouProviderWrapper();
+
 // ==================== Provider Selection ====================
 
 /**
@@ -283,6 +321,7 @@ export function getActiveProviderType(): WebSearchProviderType {
   ) as string;
   if (provider === "nanogpt") return "nanogpt";
   if (provider === "tavily") return "tavily";
+  if (provider === "you") return "you";
   return "firecrawl";
 }
 
@@ -293,6 +332,7 @@ export function getActiveProvider(): WebSearchProvider {
   const providerType = getActiveProviderType();
   if (providerType === "nanogpt") return nanogptProvider;
   if (providerType === "tavily") return tavilyProvider;
+  if (providerType === "you") return youProvider;
   return firecrawlProvider;
 }
 
@@ -302,6 +342,7 @@ export function getActiveProvider(): WebSearchProvider {
 export function getProvider(type: WebSearchProviderType): WebSearchProvider {
   if (type === "nanogpt") return nanogptProvider;
   if (type === "tavily") return tavilyProvider;
+  if (type === "you") return youProvider;
   return firecrawlProvider;
 }
 
@@ -312,7 +353,8 @@ export function isAnyProviderConfigured(): boolean {
   return (
     nanogptProvider.isConfigured() ||
     firecrawlProvider.isConfigured() ||
-    tavilyProvider.isConfigured()
+    tavilyProvider.isConfigured() ||
+    youProvider.isConfigured()
   );
 }
 
@@ -331,6 +373,7 @@ export function getConfiguredProviders(): WebSearchProviderType[] {
   if (nanogptProvider.isConfigured()) providers.push("nanogpt");
   if (firecrawlProvider.isConfigured()) providers.push("firecrawl");
   if (tavilyProvider.isConfigured()) providers.push("tavily");
+  if (youProvider.isConfigured()) providers.push("you");
   return providers;
 }
 
@@ -345,6 +388,8 @@ export function getProviderDisplayName(type: WebSearchProviderType): string {
       return "Firecrawl";
     case "tavily":
       return "Tavily";
+    case "you":
+      return "You.com";
     default:
       return type;
   }

--- a/src/modules/youSearch.ts
+++ b/src/modules/youSearch.ts
@@ -1,0 +1,137 @@
+/**
+ * You.com Search API Service
+ * Provides web search and page scraping for AI context
+ */
+
+import { config } from "../../package.json";
+
+export interface YouWebSearchResult {
+  url: string;
+  title: string;
+  description?: string;
+  snippets?: string[];
+  contents?: { markdown?: string; html?: string };
+}
+
+export interface YouSearchResponse {
+  results?: { web?: YouWebSearchResult[]; news?: YouWebSearchResult[] };
+}
+
+export interface WebSearchResult {
+  url: string;
+  title: string;
+  description?: string;
+  markdown?: string;
+  metadata?: {
+    title?: string;
+    description?: string;
+    sourceURL?: string;
+  };
+}
+
+class YouSearchService {
+  private lastRequestTime = 0;
+  private readonly minRequestInterval = 500;
+
+  private getConfig() {
+    const prefPrefix = config.prefsPrefix;
+    return {
+      apiKey: (Zotero.Prefs.get(`${prefPrefix}.youApiKey`) as string) || "",
+      searchLimit:
+        (Zotero.Prefs.get(`${prefPrefix}.youSearchLimit`) as number) || 5,
+    };
+  }
+
+  getSearchLimit(): number {
+    return this.getConfig().searchLimit;
+  }
+
+  isConfigured(): boolean {
+    return !!this.getConfig().apiKey;
+  }
+
+  private async rateLimitedFetch(url: string, options: RequestInit = {}) {
+    const now = Date.now();
+    const delta = now - this.lastRequestTime;
+    if (delta < this.minRequestInterval) {
+      await new Promise((r) => setTimeout(r, this.minRequestInterval - delta));
+    }
+    this.lastRequestTime = Date.now();
+    return fetch(url, options);
+  }
+
+  async webSearch(query: string, limit: number = 5): Promise<WebSearchResult[]> {
+    const { apiKey } = this.getConfig();
+    const url = new URL("https://api.you.com/v1/agents/search");
+    url.searchParams.set("query", query);
+    url.searchParams.set("count", String(limit));
+
+    const headers: Record<string, string> = {};
+    if (apiKey) headers["X-API-Key"] = apiKey;
+
+    const response = await this.rateLimitedFetch(url.toString(), { headers });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`you.com search error (${response.status}): ${errorText}`);
+    }
+
+    const data = (await response.json()) as YouSearchResponse;
+    const web = data.results?.web || [];
+
+    return web.map((r) => ({
+      url: r.url,
+      title: r.title,
+      description: r.snippets?.[0] || r.description || "",
+      markdown: r.contents?.markdown,
+      metadata: {
+        title: r.title,
+        description: r.description,
+        sourceURL: r.url,
+      },
+    }));
+  }
+
+  async scrapeUrl(url: string): Promise<WebSearchResult | null> {
+    const { apiKey } = this.getConfig();
+    if (!apiKey) {
+      return null;
+    }
+
+    const response = await this.rateLimitedFetch("https://ydc-index.io/v1/contents", {
+      method: "POST",
+      headers: {
+        "X-API-Key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ urls: [url], formats: ["markdown", "metadata"] }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`you.com contents error (${response.status}): ${errorText}`);
+    }
+
+    const items = (await response.json()) as Array<{
+      url: string;
+      title?: string;
+      markdown?: string;
+      metadata?: { description?: string };
+    }>;
+
+    if (!items.length) return null;
+    const item = items[0];
+    return {
+      url: item.url,
+      title: item.title || url,
+      description: item.metadata?.description,
+      markdown: item.markdown,
+      metadata: {
+        title: item.title,
+        description: item.metadata?.description,
+        sourceURL: item.url,
+      },
+    };
+  }
+}
+
+export const youSearchService = new YouSearchService();


### PR DESCRIPTION
Hi maintainers, thanks for building and maintaining SeerAI. This repo is a great fit for a You.com provider because it already has a clean web-search provider abstraction, and adding one more provider is low risk and useful for users who want another web-grounding option.

## Why this repo
- Active AI-agent/research workflow with first-class web-search tooling
- Existing provider architecture (Firecrawl/Tavily/NanoGPT) makes this a maintainable extension
- Small, isolated change with backward-compatible defaults

## What changed
- Added a new `you` provider option to the web-search provider abstraction
  - New module: `src/modules/youSearch.ts`
  - Search endpoint: `GET https://api.you.com/v1/agents/search` with `query` + `count`
  - Optional content extraction via `POST https://ydc-index.io/v1/contents`
- Wired provider selection into existing provider routing in `src/modules/webSearchProvider.ts`
- Added new preferences:
  - `youApiKey`
  - `youSearchLimit`
- Updated preferences UI:
  - Added `You.com` to provider dropdown
  - Added provider settings block for API key + search limit
- Updated README configuration docs to include You.com Search API setup

## Setup
1. Open `Zotero -> Settings -> seerai`
2. In **Web Search Integration**, choose **You.com** as provider
3. Set:
   - API key (from https://you.com/platform)
   - Search limit

## Validation
I attempted to run project checks, but this runner is missing required binaries:
- `npm test -- --runInBand` fails because `zotero-plugin` is not installed in this environment
- `npm run lint:check` fails because `prettier` is not installed in this environment

I can rerun and paste full outputs once those dependencies are available.

## Why this helps agent intelligence
- Adds another web-search backend for grounding and retrieval, reducing single-provider dependency
- Preserves existing consumer/tool interfaces, so agent workflows keep working unchanged
- Lets users choose provider based on cost/performance/availability tradeoffs

## Compatibility and risk
- Backward compatible: default provider remains unchanged
- Scoped integration: provider-specific logic is isolated to a new service and existing provider switch points

Happy to adjust naming, docs placement, or request/response handling to match your preferred conventions. Thanks again for the review and project stewardship.
